### PR TITLE
Clear right of prompt

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -79,5 +79,5 @@ function fish_prompt -d "Simple Fish Prompt"
         end
     end
 
-    __print_color FF7676 "\n❯ "
+    __print_color FF7676 "\e[K\n❯ "
 end


### PR DESCRIPTION
Clears any text to the right of the prompt. This means that when the prompt is updated (by using the fish directory jumping, for example) if the new prompt is shorter than the last, you don't have anything left over on the right-hand side. Resolves #6

Uses the `cleareol EL0` VT100 escape code for doing this and should be compatible with any VT100 compatible terminal emulator. This has been tested with `urxvt` and `xterm`.